### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/erichu30/media_organizer/security/code-scanning/4](https://github.com/erichu30/media_organizer/security/code-scanning/4)

To fix this issue, an explicit `permissions` block should be added to the workflow to restrict the `GITHUB_TOKEN`'s permissions. For a Go build and test workflow, no actions require write access; only read access to the repository contents is needed (to check out code). Therefore, the permissions block should be added at the top-level (to apply to all jobs), directly under the `name` line and above the `on` block. The correct setting is:
```yaml
permissions:
  contents: read
```
No changes to steps, imports, or jobs are required; only the addition of this block at the root workflow level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
